### PR TITLE
Updated to can be modify charset in content-type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ note that pod WSDL2Swift just introduces runtime dependencies. it does not provi
 
 sometimes, somewhere in your dependencies chain (transitive framework dependencies or test bundle), header search paths for libxml2 is required. see podspec to add manually.
 
+### Customize
+
+You can specify charset of SOAP request by editing the generated code.
+
+The following code is an example when you want to specify character code to be interpreted as utf-8.
+
+```swift
+public var characterSetInContentType: CharacterSetInContentType {
+    return .utf8
+}
+```
+
+By default, `unspecified` is set.
+
 ## Example
 
 iOSWSDL2Swift target in xcodeproj is an example using WSDL2Swift.

--- a/WSDL2Swift.podspec
+++ b/WSDL2Swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WSDL2Swift"
-  s.version      = "0.8.0.1"
+  s.version      = "0.8.1"
   s.summary      = "Swift alternative to WSDL2ObjC making a SOAP request & parsing its response as defined in WSDL"
   s.description  = <<-DESC
   Swift alternative to WSDL2ObjC making a SOAP request & parsing its response as defined in WSDL.

--- a/WSDL2Swift.podspec
+++ b/WSDL2Swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WSDL2Swift"
-  s.version      = "0.8.0"
+  s.version      = "0.8.0.1"
   s.summary      = "Swift alternative to WSDL2ObjC making a SOAP request & parsing its response as defined in WSDL"
   s.description  = <<-DESC
   Swift alternative to WSDL2ObjC making a SOAP request & parsing its response as defined in WSDL.

--- a/WSDL2Swift.swift
+++ b/WSDL2Swift.swift
@@ -63,7 +63,7 @@ public extension WSDLService {
 
         var request = URLRequest(url: URL(string: endpoint)!.appendingPathComponent(path))
         request.httpMethod = "POST"
-        request.addValue("text/xml", forHTTPHeaderField: "Content-Type")
+        request.addValue("text/xml; charset=utf-8", forHTTPHeaderField: "Content-Type")
         request.addValue("WSDL2Swift", forHTTPHeaderField: "User-Agent")
         if let data = soapRequest.xml.data(using: .utf8) {
             //            request.addValue(String(data.length), forHTTPHeaderField: "Content-Length")

--- a/WSDL2Swift.swift
+++ b/WSDL2Swift.swift
@@ -39,6 +39,20 @@ public extension XSDType {
     }
 }
 
+public enum CharacterSetInContentType {
+    case unspecified
+    case manual( String )
+    case utf8
+    
+    fileprivate var specifier: String?{
+        switch self{
+        case unspecified: return nil
+        case manual( let mimeName ): return "charset=\(mimeName)"
+        case utf8: return "charset=utf-8"
+        }
+    }
+}
+
 public protocol WSDLService {
     var endpoint: String { get set }
     var path: String { get }
@@ -46,6 +60,9 @@ public protocol WSDLService {
     var interceptURLRequest: ((URLRequest) -> URLRequest)? { get set }
     var interceptResponse: ((Data?, URLResponse?, Error?) -> (Data?, URLResponse?, Error?))? { get set }
     init(endpoint: String)
+    
+    // Implement this property when you need to specify charset
+    var characterSetInContentType: characterSetInContentType { get }
 }
 
 public extension WSDLService {
@@ -63,7 +80,8 @@ public extension WSDLService {
 
         var request = URLRequest(url: URL(string: endpoint)!.appendingPathComponent(path))
         request.httpMethod = "POST"
-        request.addValue("text/xml; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        let charset = characterSetInContentType
+        request.addValue("text/xml" + charset.specifier == nil ? "" : ";\(charset.specifier)" , forHTTPHeaderField: "Content-Type")
         request.addValue("WSDL2Swift", forHTTPHeaderField: "User-Agent")
         if let data = soapRequest.xml.data(using: .utf8) {
             //            request.addValue(String(data.length), forHTTPHeaderField: "Content-Length")
@@ -104,6 +122,11 @@ public extension WSDLService {
         }
         task.resume()
         return promise.future
+    }
+    
+    // Default charset is unspecified.
+    var characterSetInContentType: CharacterSetInContentType {
+        return .unspecified
     }
 }
 

--- a/WSDL2Swift.swift
+++ b/WSDL2Swift.swift
@@ -46,9 +46,9 @@ public enum CharacterSetInContentType {
     
     fileprivate var specifier: String?{
         switch self{
-        case unspecified: return nil
-        case manual( let mimeName ): return "charset=\(mimeName)"
-        case utf8: return "charset=utf-8"
+        case .unspecified: return nil
+        case .manual( let mimeName ): return "charset=\(mimeName)"
+        case .utf8: return "charset=utf-8"
         }
     }
 }
@@ -62,7 +62,7 @@ public protocol WSDLService {
     init(endpoint: String)
     
     // Implement this property when you need to specify charset
-    var characterSetInContentType: characterSetInContentType { get }
+    var characterSetInContentType: CharacterSetInContentType { get }
 }
 
 public extension WSDLService {
@@ -81,7 +81,7 @@ public extension WSDLService {
         var request = URLRequest(url: URL(string: endpoint)!.appendingPathComponent(path))
         request.httpMethod = "POST"
         let charset = characterSetInContentType
-        request.addValue("text/xml" + charset.specifier == nil ? "" : ";\(charset.specifier)" , forHTTPHeaderField: "Content-Type")
+        request.addValue("text/xml" + (charset.specifier == nil ? "" : ";\(charset.specifier!)") , forHTTPHeaderField: "Content-Type")
         request.addValue("WSDL2Swift", forHTTPHeaderField: "User-Agent")
         if let data = soapRequest.xml.data(using: .utf8) {
             //            request.addValue(String(data.length), forHTTPHeaderField: "Content-Length")


### PR DESCRIPTION
Thanks for your great code.

Well, I will explain this pull request. 
In my environment, it was necessary to specify charset in SORP Request.
So, by modifying the generated code, it has been modified to be able to specify.

Please let me know if there is another plan in the designated method.
Also, please let me know if there is a merge destination specified.

Thank for reading😆